### PR TITLE
Use HTTPS for jQuery CDN.

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
 
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
-<script src="http://code.jquery.com/jquery.min.js"></script>
-<script src="http://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
+<script src="https://code.jquery.com/jquery.min.js"></script>
+<script src="https://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
 <script type="text/javascript">
   var CLASSTAKENCOLOR = "#CCFFCC";
   var CLASSAVAILABLECOLOR = "#FFFF9A";


### PR DESCRIPTION
- Some browsers will refuse to include content over HTTP when the page is viewed
  over HTTPS.
